### PR TITLE
fix: allow react 19 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-babel": "^5.3.0",


### PR DESCRIPTION
close #85 and #82 . I already use it with react 19 and haven't seen any issues