### PR TITLE
Fix the AbstractCropperRef reset/refresh return types

### DIFF
--- a/src/components/AbstractCropper.tsx
+++ b/src/components/AbstractCropper.tsx
@@ -40,8 +40,8 @@ export type AbstractCropperSettingsProp<Settings extends CropperInstanceSettings
 export type AbstractCropperSettings = DefaultSettings & CoreSettings & ModifierSettings & InitializeSettings;
 
 export interface AbstractCropperRef<Settings extends AbstractCropperSettings = AbstractCropperSettings> {
-	reset: () => void;
-	refresh: () => void;
+	reset: () => Promise<void>;
+	refresh: () => Promise<void>;
 	clear: () => void;
 	setCoordinates: CropperStateHook['setCoordinates'];
 	setState: CropperStateHook['setState'];


### PR DESCRIPTION
## Problem

`AbstractCropperRef.reset` and `.refresh` are declared `() => void`, but they are **async at runtime**. In `useAbstractCropper`, `resetCropper`/`refreshCropper` are `async` functions, and the ref exposes them directly:

```ts
const resetCropper = async () => { /* ... */ };
const refreshCropper = async () => { /* ... */ };
// ...
reset: () => resetCropper(),      // returns Promise<void>
refresh: () => refreshCropper(),  // returns Promise<void>
```

So both actually return `Promise<void>`, while the public `AbstractCropperRef` interface types them as `() => void`.

TypeScript never flags this internally because `() => Promise<void>` is assignable to a `() => void` slot (the return value is treated as ignored), so the async implementation satisfies the interface silently.

## Impact

Consumers that need to sequence work after a reset/refresh settles (e.g. restoring saved coordinates only once the reset completes) can't `await` these methods without casting or suppressing `@typescript-eslint/await-thenable` / `oxlint typescript/await-thenable`, even though awaiting is the correct thing to do.

## Fix

Widen the interface to match the implementation:

```diff
- reset: () => void;
- refresh: () => void;
+ reset: () => Promise<void>;
+ refresh: () => Promise<void>;
```

`clear` is left as `() => void` — it is genuinely synchronous.

**Backward compatible:** widening the return type from `void` to `Promise<void>` doesn't affect existing callers that ignore the return value; it only makes awaiting type-check.